### PR TITLE
Values containing arrays may be returned as string causing errors gp media library

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -264,6 +264,8 @@ You can hide a row by adding a hook. Checkout this example:
 * Enhancement: Meta fields can now be (de)selected all at once on the plugin settings page.
 * Enhancement: Meta fields with array values are now properly deconstructed on export.
 * Enhancement: Added support for GravityPerks Media Library ID fields. 
+* Enhancement: Upload fields can now split into multiple rows (GravityExport).
+* Security: Upload fields now show the private download URL to avoid enumeration on public files.
 
 __Developer Updates:__
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.gravitykit.com/extensions/gravityexport/?utm_source=plu
 Tags: Gravity Forms, GravityForms, Excel, Export, Download, Entries, CSV
 Requires at least: 4.0
 Requires PHP: 7.2
-Tested up to: 6.0
+Tested up to: 6.2
 Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -262,6 +262,8 @@ You can hide a row by adding a hook. Checkout this example:
 * **This is a major update!** Enjoy the much nicer feed configuration interface!
 * Enhancement: Fields can now be enabled or disabled all at once on the form settings page.
 * Enhancement: Meta fields can now be (de)selected all at once on the plugin settings page.
+* Enhancement: Meta fields with array values are now properly deconstructed on export.
+* Enhancement: Added support for GravityPerks Media Library ID fields.
 
 __Developer Updates:__
 

--- a/readme.txt
+++ b/readme.txt
@@ -263,7 +263,7 @@ You can hide a row by adding a hook. Checkout this example:
 * Enhancement: Fields can now be enabled or disabled all at once on the form settings page.
 * Enhancement: Meta fields can now be (de)selected all at once on the plugin settings page.
 * Enhancement: Meta fields with array values are now properly deconstructed on export.
-* Enhancement: Added support for GravityPerks Media Library ID fields.
+* Enhancement: Added support for GravityPerks Media Library ID fields. 
 
 __Developer Updates:__
 

--- a/src/Field/Meta/DateCreated.php
+++ b/src/Field/Meta/DateCreated.php
@@ -3,7 +3,6 @@
 namespace GFExcel\Field\Meta;
 
 use GFExcel\Field\MetaField;
-use GFExcel\GFExcel;
 use GFExcel\Values\BaseValue;
 
 class DateCreated extends MetaField

--- a/src/Field/Meta/GPMediaLibrary.php
+++ b/src/Field/Meta/GPMediaLibrary.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace GFExcel\Field\Meta;
+
+use GFExcel\Field\MetaField;
+use GFExcel\Field\RowsInterface;
+
+/**
+ * Meta field transformer for GP Media Library ID field.
+ * @since $ver$
+ */
+final class GPMediaLibrary extends MetaField implements RowsInterface {
+	/**
+	 * @inheritDoc
+	 * @since $ver$
+	 */
+	protected function getFieldValue( $entry, $input_id = '' ) {
+		$field_id = $this->field->id;
+		$value    = parent::getFieldValue( $entry, $input_id );
+
+		if ( ! is_array( $value ) ) {
+			return parent::getFieldValue( $entry, $input_id );
+		}
+
+		if ( ! function_exists( 'gp_media_library' ) ) {
+			return implode( ', ', $value );
+		}
+
+		return gp_media_library()->format_entry_meta_for_display(
+			$value,
+			$this->field->form_id,
+			$field_id,
+			$entry
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since $ver$
+	 */
+	public function getRows( ?array $entry = null ): iterable {
+		$value = parent::getFieldValue( $entry );
+
+		if ( ! is_array( $value ) ) {
+			yield parent::getCells( $entry );
+		} else {
+			foreach ( $value as $id ) {
+				yield $this->wrap( [ $id ] );
+			}
+		}
+	}
+}

--- a/src/Field/MetaField.php
+++ b/src/Field/MetaField.php
@@ -4,16 +4,17 @@ namespace GFExcel\Field;
 
 use GFExcel\Values\BaseValue;
 
-class MetaField extends BaseField
+class MetaField extends BaseField implements RowsInterface
 {
     /**
      * List of internal subfields.
      * @var string[]
      */
-    protected $subfields = array(
+    protected $subfields = [
         'created_by' => 'GFExcel\Field\Meta\CreatedBy',
         'date_created' => 'GFExcel\Field\Meta\DateCreated',
-    );
+	    '/gpml_ids_\d+/is' => 'GFExcel\Field\Meta\GPMediaLibrary',
+    ];
 
     /**
      * {@inheritdoc}
@@ -79,20 +80,39 @@ class MetaField extends BaseField
 
     /**
      * Get a subfield instance if available.
-     * @return FieldInterface|false
+     * @return FieldInterface|null
      */
-    private function getSubField()
-    {
-        // prevent endless loop, and be able to extend MetaField.
-        if (get_class($this) !== self::class) {
-            return false;
-        }
+	private function getSubField() {
+		// prevent endless loop, and be able to extend MetaField.
+		if ( get_class( $this ) !== self::class ) {
+			return null;
+		}
 
-        $fields = $this->getSubFieldsClasses();
-        if (!array_key_exists($this->field->id, $fields)) {
-            return false;
-        }
+		$fields = $this->getSubFieldsClasses();
+		if ( array_key_exists( $this->field->id, $fields ) ) {
+			return new $fields[ $this->field->id ]( $this->field );
+		}
 
-        return new $fields[$this->field->id]($this->field);
-    }
+		foreach ( $fields as $name => $field ) {
+			// Check if one of the fields is actually a regex.
+			if ( @ preg_match( $name, $this->field->id ) ) {
+				return new $field( $this->field );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since $ver$
+	 */
+	public function getRows( ?array $entry = null ): iterable {
+		$subfield = $this->getSubField();
+		if ($subfield instanceof RowsInterface) {
+			yield from $subfield->getRows($entry);
+		} else {
+			yield $this->getCells($entry);
+		}
+	}
 }

--- a/src/Values/BaseValue.php
+++ b/src/Values/BaseValue.php
@@ -8,493 +8,493 @@ use GFExcel\Field\AbstractField;
 /**
  * @since 1.3.0
  */
-abstract class BaseValue
-{
-    /**
-     * Variable representing a boolean cell.
-     * @since 1.3.0
-     * @var string
-     */
-    public const TYPE_BOOL = 'bool';
+abstract class BaseValue {
+	/**
+	 * Variable representing a boolean cell.
+	 * @since 1.3.0
+	 * @var string
+	 */
+	public const TYPE_BOOL = 'bool';
 
-    /**
-     * Variable representing a numeric cell.
-     * @since 1.3.0
-     * @var string
-     */
-    public const TYPE_NUMERIC = 'numeric';
+	/**
+	 * Variable representing a numeric cell.
+	 * @since 1.3.0
+	 * @var string
+	 */
+	public const TYPE_NUMERIC = 'numeric';
 
-    /**
-     * Variable representing a string cell (default).
-     * @since 1.3.0
-     * @var string
-     */
-    public const TYPE_STRING = 'string';
+	/**
+	 * Variable representing a string cell (default).
+	 * @since 1.3.0
+	 * @var string
+	 */
+	public const TYPE_STRING = 'string';
 
-    /**
-     * Variable representing a boolean cell.
-     * @since 1.8.0
-     * @var string
-     */
-    public const TYPE_CURRENCY = 'currency';
+	/**
+	 * Variable representing a boolean cell.
+	 * @since 1.8.0
+	 * @var string
+	 */
+	public const TYPE_CURRENCY = 'currency';
 
-    /**
-     * The value of the cell.
-     * @since 1.3.0
-     * @var mixed
-     */
-    protected $value = '';
+	/**
+	 * The value of the cell.
+	 * @since 1.3.0
+	 * @var mixed
+	 */
+	protected $value = '';
 
-    /**
-     * The gravity forms field for this value.
-     * @since 1.3.0
-     * @var \GF_Field
-     */
-    protected $gf_field;
+	/**
+	 * The gravity forms field for this value.
+	 * @since 1.3.0
+	 * @var \GF_Field
+	 */
+	protected $gf_field;
 
-    /**
-     * Whether this is a numeric value.
-     * @since 1.3.0
-     * @var bool
-     */
-    protected $is_numeric = false;
+	/**
+	 * Whether this is a numeric value.
+	 * @since 1.3.0
+	 * @var bool
+	 */
+	protected $is_numeric = false;
 
-    /**
-     * The text color of the cell.
-     * @since 1.4.1
-     * @var string
-     */
-    protected $color = '';
+	/**
+	 * The text color of the cell.
+	 * @since 1.4.1
+	 * @var string
+	 */
+	protected $color = '';
 
-    /**
-     * The background color of the cell.
-     * @since 1.4.1
-     * @var string
-     */
-    protected $background_color = '';
+	/**
+	 * The background color of the cell.
+	 * @since 1.4.1
+	 * @var string
+	 */
+	protected $background_color = '';
 
-    /**
-     * Whether the value is bold.
-     * @since 1.4.0
-     * @var bool
-     */
-    protected $is_bold = false;
+	/**
+	 * Whether the value is bold.
+	 * @since 1.4.0
+	 * @var bool
+	 */
+	protected $is_bold = false;
 
-    /**
-     * Whether the value is italic.
-     * @since 1.4.0
-     * @var bool
-     */
-    protected $is_italic = false;
+	/**
+	 * Whether the value is italic.
+	 * @since 1.4.0
+	 * @var bool
+	 */
+	protected $is_italic = false;
 
-    /**
-     * Whether the value is a boolean value.
-     * @since 1.3.0
-     * @var bool
-     */
-    protected $is_bool = false;
+	/**
+	 * Whether the value is a boolean value.
+	 * @since 1.3.0
+	 * @var bool
+	 */
+	protected $is_bool = false;
 
-    /**
-     * The url of the cell..
-     * @since 1.4.0
-     * @var string
-     */
-    protected $url;
+	/**
+	 * The url of the cell.
+	 * @since 1.4.0
+	 * @var string
+	 */
+	protected $url;
 
-    /**
-     * The specific font size for this value.
-     * @since 1.8.0
-     * @var null|float
-     */
-    protected $font_size;
+	/**
+	 * The specific font size for this value.
+	 * @since 1.8.0
+	 * @var null|float
+	 */
+	protected $font_size;
 
-    /**
-     * The color of the border of the cell.
-     * @since 1.8.0
-     * @var string
-     */
-    protected $border_color = '';
+	/**
+	 * The color of the border of the cell.
+	 * @since 1.8.0
+	 * @var string
+	 */
+	protected $border_color = '';
 
-    /**
-     * The position of the border.
-     * @since 1.8.0
-     * @var string
-     */
-    protected $border_position = '';
+	/**
+	 * The position of the border.
+	 * @since 1.8.0
+	 * @var string
+	 */
+	protected $border_position = '';
 
-    /**
-     * Creates a BaseValue instance.
-     * @since 1.3.0
-     * @param mixed $value The original value.
-     * @param \GF_Field $gf_field The GF_Field instance.
-     */
-    public function __construct($value, \GF_Field $gf_field)
-    {
-        $this->value = $value;
-        $this->gf_field = $gf_field;
-    }
+	/**
+	 * Creates a BaseValue instance.
+	 * @since 1.3.0
+	 *
+	 * @param mixed $value The original value.
+	 * @param \GF_Field $gf_field The GF_Field instance.
+	 */
+	public function __construct( $value, \GF_Field $gf_field ) {
+		$this->value    = $value;
+		$this->gf_field = $gf_field;
+	}
 
-    /**
-     * Fetch a value object for the field
-     * @since 1.3.0
-     * @param AbstractField $field The field.
-     * @param mixed $value The value from the entry.
-     * @param \GF_Field $gf_field The original GF Field instance.
-     * @param bool $is_label Whether this value object is a label.
-     * @return BaseValue The value object.
-     */
-    public static function getValueObject(AbstractField $field, $value, \GF_Field $gf_field, $is_label = false)
-    {
-        $type = gf_apply_filters(
-            [
-                'gfexcel_value_type',
-                $gf_field->get_input_type(),
-                $gf_field->formId,
-                $gf_field->id
-            ],
-            $field->getValueType(),
-            $gf_field,
-            $is_label
-        );
+	/**
+	 * Fetch a value object for the field
+	 * @since 1.3.0
+	 *
+	 * @param AbstractField $field The field.
+	 * @param mixed $value The value from the entry.
+	 * @param \GF_Field $gf_field The original GF Field instance.
+	 * @param bool $is_label Whether this value object is a label.
+	 *
+	 * @return BaseValue The value object.
+	 */
+	public static function getValueObject( AbstractField $field, $value, \GF_Field $gf_field, $is_label = false ) {
+		$type = gf_apply_filters(
+			[
+				'gfexcel_value_type',
+				$gf_field->get_input_type(),
+				$gf_field->formId,
+				$gf_field->id
+			],
+			$field->getValueType(),
+			$gf_field,
+			$is_label
+		);
 
-        // Labels are always parsed as a string.
-        if ($is_label) {
-            $type = BaseValue::TYPE_STRING;
-        }
+		// Labels are always parsed as a string.
+		if ( $is_label ) {
+			$type = BaseValue::TYPE_STRING;
+		}
 
-        $typeClass = 'GFExcel\\Values\\' . ucfirst($type) . 'Value';
-        if (!class_exists($typeClass)) {
-            // fall back to StringValue
-            $typeClass = StringValue::class;
-        }
+		$typeClass = 'GFExcel\\Values\\' . ucfirst( $type ) . 'Value';
+		if ( ! class_exists( $typeClass ) ) {
+			// fall back to StringValue
+			$typeClass = StringValue::class;
+		}
 
-        $valueObject = new $typeClass($value, $gf_field);
+		$valueObject = new $typeClass( $value, $gf_field );
 
-        // Changes to the value object should be done by reference, so we replace change the object itself.
-        gf_apply_filters([
-            'gfexcel_value_object',
-            $gf_field->get_input_type(),
-            $gf_field->formId,
-            $gf_field->id
-        ], $valueObject, $gf_field, $is_label);
+		// Changes to the value object should be done by reference, so we replace change the object itself.
+		gf_apply_filters( [
+			'gfexcel_value_object',
+			$gf_field->get_input_type(),
+			$gf_field->formId,
+			$gf_field->id
+		], $valueObject, $gf_field, $is_label );
 
-        return $valueObject;
-    }
+		return $valueObject;
+	}
 
-    /**
-     * A string representation of the value object.
-     * @since 1.3.0
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string) $this->value;
-    }
+	/**
+	 * A string representation of the value object.
+	 * @since 1.3.0
+	 * @return string
+	 */
+	public function __toString() {
+		return (string) $this->getValue();
+	}
 
-    /**
-     * Returns the (string) value of this instance.
-     * @since 1.3.0
-     * @return mixed
-     */
-    public function getValue()
-    {
-        return (string) $this->value;
-    }
+	/**
+	 * Returns the (string) value of this instance.
+	 * @since 1.3.0
+	 * @return mixed
+	 */
+	public function getValue() {
+		if ( ! is_array( $this->value ) ) {
+			return (string) $this->value;
+		}
 
-    /**
-     * Returns whether this value is numeric.
-     * @since 1.3.0
-     * @return bool Whether this value object is numeric.
-     */
-    public function isNumeric()
-    {
-        return (bool) $this->is_numeric;
-    }
+		// Flatten array.
+		$value = [];
+		array_walk_recursive( $this->value, function ( $a ) use ( &$value ) {
+			$value[] = (string) $a;
+		} );
 
-    /**
-     * Returns whether this value is a boolean.
-     * @since 1.3.0
-     * @return bool
-     */
-    public function isBool()
-    {
-        return (bool) $this->is_bool;
-    }
+		return implode( ', ', $value );
+	}
 
-    /**
-     * Returns whether this value is bold.
-     * @since 1.4.0
-     * @return bool
-     */
-    public function isBold()
-    {
-        return (bool) $this->is_bold;
-    }
+	/**
+	 * Returns whether this value is numeric.
+	 * @since 1.3.0
+	 * @return bool Whether this value object is numeric.
+	 */
+	public function isNumeric() {
+		return (bool) $this->is_numeric;
+	}
 
-    /**
-     * Returns whether this value is italic.
-     * @since 1.4.0
-     * @return bool
-     */
-    public function isItalic()
-    {
-        return (bool) $this->is_italic;
-    }
+	/**
+	 * Returns whether this value is a boolean.
+	 * @since 1.3.0
+	 * @return bool
+	 */
+	public function isBool() {
+		return (bool) $this->is_bool;
+	}
 
-    /**
-     * Returns the text color (in HEX) of the value.
-     * @since 1.4.0
-     * @return string|null The color.
-     * @throws WrongValueException When the provided color was incorrect.
-     */
-    public function getColor()
-    {
-        if (!$this->color) {
-            return null;
-        }
+	/**
+	 * Returns whether this value is bold.
+	 * @since 1.4.0
+	 * @return bool
+	 */
+	public function isBold() {
+		return (bool) $this->is_bold;
+	}
 
-        if ($this->color[0] !== '#' || strlen($this->color) !== 7) {
-            throw new WrongValueException(
-                'The color should receive a full 6-digit hex-color and a pound sign. eg. #000000.'
-            );
-        }
+	/**
+	 * Returns whether this value is italic.
+	 * @since 1.4.0
+	 * @return bool
+	 */
+	public function isItalic() {
+		return (bool) $this->is_italic;
+	}
 
-        return substr($this->color, 1);
-    }
+	/**
+	 * Returns the text color (in HEX) of the value.
+	 * @since 1.4.0
+	 * @return string|null The color.
+	 * @throws WrongValueException When the provided color was incorrect.
+	 */
+	public function getColor() {
+		if ( ! $this->color ) {
+			return null;
+		}
 
-    /**
-     * * Returns the color (in HEX) of the background.
-     * @since 1.4.0
-     * @return string|null The color.
-     * @throws WrongValueException When the provided color was incorrect.
-     */
-    public function getBackgroundColor()
-    {
-        if (!$this->background_color) {
-            return null;
-        }
+		if ( $this->color[0] !== '#' || strlen( $this->color ) !== 7 ) {
+			throw new WrongValueException(
+				'The color should receive a full 6-digit hex-color and a pound sign. eg. #000000.'
+			);
+		}
 
-        if ($this->background_color[0] !== '#' || strlen($this->background_color) !== 7) {
-            throw new WrongValueException(
-                'The background color should receive a full 6-digit hex-color and a pound sign. eg. #000000.'
-            );
-        }
+		return substr( $this->color, 1 );
+	}
 
-        return substr($this->background_color, 1);
-    }
+	/**
+	 * * Returns the color (in HEX) of the background.
+	 * @since 1.4.0
+	 * @return string|null The color.
+	 * @throws WrongValueException When the provided color was incorrect.
+	 */
+	public function getBackgroundColor() {
+		if ( ! $this->background_color ) {
+			return null;
+		}
 
-    /**
-     * Returns the url of the cell if provided.
-     * @since 1.3.0
-     * @return string|null The url.
-     */
-    public function getUrl()
-    {
-        if (!$this->url) {
-            return null;
-        }
+		if ( $this->background_color[0] !== '#' || strlen( $this->background_color ) !== 7 ) {
+			throw new WrongValueException(
+				'The background color should receive a full 6-digit hex-color and a pound sign. eg. #000000.'
+			);
+		}
 
-        return trim(strip_tags($this->url));
-    }
+		return substr( $this->background_color, 1 );
+	}
 
-    /**
-     * Set the url of the value.
-     * @since 1.3.0
-     * @param string $url The url.
-     * @return self This instance.
-     */
-    public function setUrl($url)
-    {
-        $this->url = $url;
+	/**
+	 * Returns the url of the cell if provided.
+	 * @since 1.3.0
+	 * @return string|null The url.
+	 */
+	public function getUrl() {
+		if ( ! $this->url ) {
+			return null;
+		}
 
-        return $this;
-    }
+		return trim( strip_tags( $this->url ) );
+	}
 
-    /**
-     * Set the color of the value
-     * @since 1.4.0
-     * @param string $hexcode The color.
-     * @return self This instance.
-     */
-    public function setColor($hexcode = '#000000')
-    {
-        $this->color = $hexcode;
+	/**
+	 * Set the url of the value.
+	 * @since 1.3.0
+	 *
+	 * @param string $url The url.
+	 *
+	 * @return self This instance.
+	 */
+	public function setUrl( $url ) {
+		$this->url = $url;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Set the color of the cell background.
-     * @since 1.4.0
-     * @param string $color The hex color.
-     * @return self This instance.
-     */
-    public function setBackgroundColor($color = '')
-    {
-        $this->background_color = $color;
+	/**
+	 * Set the color of the value
+	 * @since 1.4.0
+	 *
+	 * @param string $hexcode The color.
+	 *
+	 * @return self This instance.
+	 */
+	public function setColor( $hexcode = '#000000' ) {
+		$this->color = $hexcode;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Set the value to bold.
-     * @since 1.4.0
-     * @param bool $bold Whether the text should be bold.
-     * @return self This instance.
-     */
-    public function setBold($bold = true)
-    {
-        $this->is_bold = (boolean) $bold;
+	/**
+	 * Set the color of the cell background.
+	 * @since 1.4.0
+	 *
+	 * @param string $color The hex color.
+	 *
+	 * @return self This instance.
+	 */
+	public function setBackgroundColor( $color = '' ) {
+		$this->background_color = $color;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Set the value to italic.
-     * @since 1.4.0
-     * @param bool $italic Whether the text should be italic.
-     * @return self This instance.
-     */
-    public function setItalic($italic = true)
-    {
-        $this->is_italic = (boolean) $italic;
+	/**
+	 * Set the value to bold.
+	 * @since 1.4.0
+	 *
+	 * @param bool $bold Whether the text should be bold.
+	 *
+	 * @return self This instance.
+	 */
+	public function setBold( $bold = true ) {
+		$this->is_bold = (boolean) $bold;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Sets the font size of this value.
-     * @since 1.8.0
-     * @param null|float $font_size The font size in pt.
-     * @return self This instance.
-     */
-    public function setFontSize(?float $font_size): self
-    {
-        $this->font_size = $font_size;
+	/**
+	 * Set the value to italic.
+	 * @since 1.4.0
+	 *
+	 * @param bool $italic Whether the text should be italic.
+	 *
+	 * @return self This instance.
+	 */
+	public function setItalic( $italic = true ) {
+		$this->is_italic = (boolean) $italic;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Returns the font size in pt.
-     * @since 1.8.0
-     * @return float|null The font size in pt.
-     */
-    public function getFontSize(): ?float
-    {
-        return $this->font_size;
-    }
+	/**
+	 * Sets the font size of this value.
+	 * @since 1.8.0
+	 *
+	 * @param null|float $font_size The font size in pt.
+	 *
+	 * @return self This instance.
+	 */
+	public function setFontSize( ?float $font_size ): self {
+		$this->font_size = $font_size;
 
-    /**
-     * Get the GF_Field object
-     * @since 1.5.5
-     * @return \GF_Field The GF_Field object.
-     */
-    public function getField()
-    {
-        return $this->gf_field;
-    }
+		return $this;
+	}
 
-    /**
-     * Get the name of the field type.
-     * @since 1.5.5
-     * @return string The field type.
-     */
-    public function getFieldType()
-    {
-        return $this->getField()->get_input_type();
-    }
+	/**
+	 * Returns the font size in pt.
+	 * @since 1.8.0
+	 * @return float|null The font size in pt.
+	 */
+	public function getFontSize(): ?float {
+		return $this->font_size;
+	}
 
-    /**
-     * Get the ID for this field
-     * @since 1.5.5
-     * @return string|null The id.
-     */
-    public function getFieldId()
-    {
-        return (string) $this->getField()->id;
-    }
+	/**
+	 * Get the GF_Field object
+	 * @since 1.5.5
+	 * @return \GF_Field The GF_Field object.
+	 */
+	public function getField() {
+		return $this->gf_field;
+	}
 
-    /**
-     * Whether this cell has a border.
-     * @since 1.8.0
-     * @return bool Whether this cell has a border.
-     */
-    public function hasBorder(): bool
-    {
-        return !empty($this->border_position);
-    }
+	/**
+	 * Get the name of the field type.
+	 * @since 1.5.5
+	 * @return string The field type.
+	 */
+	public function getFieldType() {
+		return $this->getField()->get_input_type();
+	}
 
-    /**
-     * Returns the color of the border.
-     * @since 1.8.0
-     * @return string|null The color of the border.
-     * @throws WrongValueException when the color is nog valid.
-     */
-    public function getBorderColor(): ?string
-    {
-        if (empty($this->border_color) || !$this->hasBorder()) {
-            return null;
-        }
+	/**
+	 * Get the ID for this field
+	 * @since 1.5.5
+	 * @return string|null The id.
+	 */
+	public function getFieldId() {
+		return (string) $this->getField()->id;
+	}
 
-        if ($this->border_color[0] !== '#' || strlen($this->border_color) !== 7) {
-            throw new WrongValueException(
-                'The color should receive a full 6-digit hex-color and a pound sign. eg. #000000.'
-            );
-        }
+	/**
+	 * Whether this cell has a border.
+	 * @since 1.8.0
+	 * @return bool Whether this cell has a border.
+	 */
+	public function hasBorder(): bool {
+		return ! empty( $this->border_position );
+	}
 
-        return substr($this->border_color, 1);
-    }
+	/**
+	 * Returns the color of the border.
+	 * @since 1.8.0
+	 * @return string|null The color of the border.
+	 * @throws WrongValueException when the color is nog valid.
+	 */
+	public function getBorderColor(): ?string {
+		if ( empty( $this->border_color ) || ! $this->hasBorder() ) {
+			return null;
+		}
 
-    /**
-     * The position of the border.
-     * @since 1.8.0
-     * @return string|null The position of the border. (left, right, top, bottom, allBorders).
-     * @throws WrongValueException When an invalid position was provided.
-     */
-    public function getBorderPosition(): ?string
-    {
-        if (!$this->hasBorder()) {
-            return null;
-        }
+		if ( $this->border_color[0] !== '#' || strlen( $this->border_color ) !== 7 ) {
+			throw new WrongValueException(
+				'The color should receive a full 6-digit hex-color and a pound sign. eg. #000000.'
+			);
+		}
 
-        $positions = ['left', 'right', 'top', 'bottom', 'allBorders'];
-        if (!in_array($this->border_position, $positions, true)) {
-            throw new WrongValueException(sprintf(
-                'The border position "%s" is invalid. It should be one of: %s.',
-                $this->border_position,
-                implode(', ', $positions)
-            ));
-        }
+		return substr( $this->border_color, 1 );
+	}
 
-        return $this->border_position;
-    }
+	/**
+	 * The position of the border.
+	 * @since 1.8.0
+	 * @return string|null The position of the border. (left, right, top, bottom, allBorders).
+	 * @throws WrongValueException When an invalid position was provided.
+	 */
+	public function getBorderPosition(): ?string {
+		if ( ! $this->hasBorder() ) {
+			return null;
+		}
 
-    /**
-     * Sets the border for a cell.
-     * @since 1.8.0
-     * @param string $color The color of the border.
-     * @param string $position The position of the border.
-     * @return self This instance.
-     */
-    public function setBorder(string $color = '', string $position = 'allBorders'): self
-    {
-        $this->border_color = $color;
-        $this->border_position = $position;
+		$positions = [ 'left', 'right', 'top', 'bottom', 'allBorders' ];
+		if ( ! in_array( $this->border_position, $positions, true ) ) {
+			throw new WrongValueException( sprintf(
+				'The border position "%s" is invalid. It should be one of: %s.',
+				$this->border_position,
+				implode( ', ', $positions )
+			) );
+		}
 
-        return $this;
-    }
+		return $this->border_position;
+	}
 
-    /**
-     * Remove the border from a cell.
-     * @since 1.8.0
-     * @return self This instance.
-     */
-    public function removeBorder(): self
-    {
-        $this->border_color = '';
-        $this->border_position = '';
+	/**
+	 * Sets the border for a cell.
+	 * @since 1.8.0
+	 *
+	 * @param string $color The color of the border.
+	 * @param string $position The position of the border.
+	 *
+	 * @return self This instance.
+	 */
+	public function setBorder( string $color = '', string $position = 'allBorders' ): self {
+		$this->border_color    = $color;
+		$this->border_position = $position;
 
-        return $this;
-    }
+		return $this;
+	}
+
+	/**
+	 * Remove the border from a cell.
+	 * @since 1.8.0
+	 * @return self This instance.
+	 */
+	public function removeBorder(): self {
+		$this->border_color    = '';
+		$this->border_position = '';
+
+		return $this;
+	}
 }

--- a/src/Values/StringValue.php
+++ b/src/Values/StringValue.php
@@ -8,34 +8,38 @@ use GFExcel\Addon\GravityExportAddon;
  * Value object that represents a string.
  * @since 1.3.0
  */
-class StringValue extends BaseValue
-{
-    /**
-     * @inheritDoc
-     * @since 1.3.0
-     */
-    public function __construct($value, \GF_Field $gf_field)
-    {
-        parent::__construct($value, $gf_field);
+class StringValue extends BaseValue {
+	/**
+	 * @inheritDoc
+	 * @since 1.3.0
+	 */
+	public function __construct( $value, \GF_Field $gf_field ) {
+		parent::__construct( $value, $gf_field );
 
-        $this->setUrlAsLink();
-    }
+		$this->setUrlAsLink();
+	}
 
 	/**
 	 * Check if the value is a URL, and set that URL as a link on the cell.
 	 * @since 1.3.0
 	 */
 	protected function setUrlAsLink(): void {
-		if ( $this->isUrl( $this->value ) && $this->hasHyperlinksEnabled() ) {
+		if (
+			is_string( $this->value )
+			&& $this->isUrl( $this->value )
+			&& $this->hasHyperlinksEnabled()
+		) {
 			$this->setUrl( $this->value );
 		}
 	}
 
-    /**
-     * Quick test if value is a URL.
-     * @param string $value The value.
-     * @return bool Whether the value is a URL.
-     */
+	/**
+	 * Quick test if value is a URL.
+	 *
+	 * @param string $value The value.
+	 *
+	 * @return bool Whether the value is a URL.
+	 */
 	protected function isUrl( string $value ): bool {
 		return (bool) preg_match(
 			'%^(https?|ftps?)://([A-Z0-9][A-Z0-9_-]*(?:.[A-Z0-9][A-Z0-9_-]*)+):?(d+)?/?%i',
@@ -43,11 +47,11 @@ class StringValue extends BaseValue
 		);
 	}
 
-    /**
-     * Returns whether the `hyperlinks_enabled` setting is true.
-     * @since 1.3.0
-     * @return bool Whether the hyperlinks are enabled.
-     */
+	/**
+	 * Returns whether the `hyperlinks_enabled` setting is true.
+	 * @since 1.3.0
+	 * @return bool Whether the hyperlinks are enabled.
+	 */
 	private function hasHyperlinksEnabled(): bool {
 		return (bool) ( GravityExportAddon::get_instance()->get_plugin_setting( 'hyperlinks_enabled' ) ?? true );
 	}


### PR DESCRIPTION
This PR Resolves #152 

- [x] Default support for values that are arrays (recursively merged with `, `)
- [x] Support for GravityPerks Media Library ID meta fields using their native functions
- [x] Support for multisplit values on that new field. 