### PR TITLE
Prevents notification error from bubbling up to end user.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= 2.0.1 on Jun 2, 2023 =
+
+* Bugfix: The notification for the migration could throw an exception in some instances.
+
 = 2.0 on May 29, 2023 =
 
 * **This is a major update!** Enjoy the much nicer feed configuration interface!

--- a/src/Migration/Exception/NonBreakingMigrationException.php
+++ b/src/Migration/Exception/NonBreakingMigrationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GFExcel\Migration\Exception;
+
+/**
+ * Exception that represents that something went wrong, but it should not break the migration (or process).
+ * @since $ver$
+ */
+final class NonBreakingMigrationException extends MigrationException {
+}

--- a/src/Migration/Manager/MigrationManager.php
+++ b/src/Migration/Manager/MigrationManager.php
@@ -4,6 +4,7 @@ namespace GFExcel\Migration\Manager;
 
 use GFExcel\Addon\GravityExportAddon;
 use GFExcel\Migration\Exception\MigrationException;
+use GFExcel\Migration\Exception\NonBreakingMigrationException;
 use GFExcel\Migration\Migration\Migration;
 use GFExcel\Migration\Repository\MigrationRepositoryInterface;
 use GFExcel\Notification\Manager\NotificationManager;
@@ -85,7 +86,12 @@ class MigrationManager {
 
 			// Run migrations.
 			foreach ( $this->getMigrations() as $migration ) {
-				$migration->run();
+				try {
+					$migration->run();
+				} catch ( NonBreakingMigrationException $e ) {
+					// Log the exception, but keep migrating.
+					GravityExportAddon::get_instance()->log_error( sprintf( 'Non breaking migration error: %s', $e->getMessage() ) );
+				}
 			}
 
 			// Update version.

--- a/src/Migration/Migration/SingleFeedMigration.php
+++ b/src/Migration/Migration/SingleFeedMigration.php
@@ -4,6 +4,9 @@ namespace GFExcel\Migration\Migration;
 
 use GFExcel\Addon\GravityExportAddon;
 use GFExcel\Migration\Exception\MigrationException;
+use GFExcel\Migration\Exception\NonBreakingMigrationException;
+use GFExcel\Notification\Exception\NotificationException;
+use GFExcel\Notification\Exception\NotificationManagerException;
 use GFExcel\Notification\Notification;
 
 /**
@@ -60,14 +63,18 @@ final class SingleFeedMigration extends Migration {
 
 		if ($this->manager) {
 			$notifications = $this->manager->getNotificationManager();
-			$notifications->storeNotification(new Notification(
-				'gk/gravity-export-migration/2.0.0',
-				sprintf(
-					esc_html__('The settings for %s 2.0 were migrated successfully.', 'gk-gravityexport-lite'),
-					defined( 'GK_GRAVITYEXPORT_PLUGIN_VERSION' ) ? 'GravityExport' : 'GravityExport Lite'
-				),
-				Notification::TYPE_SUCCESS
-			));
+			try {
+				$notifications->storeNotification( new Notification(
+					'gk/gravity-export-migration/2.0.0',
+					sprintf(
+						esc_html__( 'The settings for %s 2.0 were migrated successfully.', 'gk-gravityexport-lite' ),
+						defined( 'GK_GRAVITYEXPORT_PLUGIN_VERSION' ) ? 'GravityExport' : 'GravityExport Lite'
+					),
+					Notification::TYPE_SUCCESS
+				) );
+			} catch ( NotificationException|NotificationManagerException $e ) {
+				throw new NonBreakingMigrationException( $e->getMessage(), $e->getCode(), $e );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR resolves an issue where the notification could not be stored, and this exception bubbles up to the end user. 
https://wordpress.org/support/topic/php-fatal-error-notifications-could-not-be-stored/#post-16788286

I'm catching the exception, and re-throwing it as a `MigrationException`; because these are simply logged. 

However, since this exception isn't breaking the migration itself (just the storing of the notification about it) I added a `NonBreakingMigrationException` which will be caught earlier and logged; but will not break the migration process. 