### PR TITLE
Get correct feed_id for notification attachment

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Bugfix: Attachments could have the wrong fields.
+
 = 2.0.1 on Jun 2, 2023 =
 
 * Bugfix: The notification for the migration could throw an exception in some instances.

--- a/src/Action/NotificationAttachmentAction.php
+++ b/src/Action/NotificationAttachmentAction.php
@@ -2,6 +2,7 @@
 
 namespace GFExcel\Action;
 
+use GFExcel\Addon\GravityExportAddon;
 use GFExcel\GFExcel;
 use GFExcel\GFExcelOutput;
 use GFExcel\Repository\FormsRepository;
@@ -46,8 +47,11 @@ final class NotificationAttachmentAction {
 			return $notification;
 		}
 
+		$feed    = GravityExportAddon::get_instance()->get_feed_by_form_id( $form['id'] );
+		$feed_id = $feed['id'] ?? null;
+
 		// create a file based on the settings in the form, with only this entry.
-		$output = new GFExcelOutput( $form['id'], GFExcel::getRenderer( $form['id'] ) );
+		$output = new GFExcelOutput( $form['id'], GFExcel::getRenderer( $form['id'] ), null, $feed_id );
 		$output->setEntries( [ $entry ] );
 
 		// save the file to a temporary file


### PR DESCRIPTION
This PR fixes #167 

The problem is that the `GFExcelOutput::getFeed()` method will return the first feed it finds, if no feed_id was provided. 

Therefor the attachment can locate the wrong feed; which does not have the proper disabled fields; so it just shows everything. 

Primary fix is to include the correct feed id in the attachment; coming from the new Addon.
Secondary fix is to only retrieve the feed, if the feed_id was set.