### PR TITLE
Prevents throwing errors when a notification is malformed.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Bugfix: Prevents throwing errors on a malformed notification.
+
 = 2.0.3 on June 7, 2023 =
 
 * Bugfix: Filtering on URL's didn't work on the old download URL structure anymore.

--- a/src/Action/NotificationAttachmentAction.php
+++ b/src/Action/NotificationAttachmentAction.php
@@ -35,11 +35,16 @@ final class NotificationAttachmentAction {
 	 *
 	 * @param array $form The form object.
 	 * @param array $entry The entry object.
-	 * @param array $notification The notification object.
+	 * @param mixed $notification The notification object.
 	 *
-	 * @return array The notification with attachment.
+	 * @return mixed The notification with attachment.
 	 */
-	private function handle_notification( array $notification, array $form, array $entry ): array {
+	private function handle_notification( $notification, array $form, array $entry ) {
+		// in some cases an notification can be something else than an array.
+		if ( ! is_array( $notification ) ) {
+			return $notification;
+		}
+
 		// get notification to add to by form setting
 		$repository = new FormsRepository( $form['id'] );
 		if ( $repository->getSelectedNotification() !== \rgar( $notification, 'id' ) ) {


### PR DESCRIPTION
I'm not all for this change; because we are fixing other peoples mistakes. It only looks like we are to blame because we are fed a wrong parameter by a different hook that is misconfigured. This is the most pragmatic change. But allowing this will open the door to this change on almost any hook we utilize.