### PR TITLE
Fixed missing values on transposing.

### DIFF
--- a/gfexcel.php
+++ b/gfexcel.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     GravityExport Lite
- * Version:         2.0.5
+ * Version:         2.0.6
  * Plugin URI:      https://gfexcel.com
  * Description:     Export all Gravity Forms entries to Excel (.xlsx) or CSV via a secret shareable URL.
  * Author:          GravityKit
@@ -29,7 +29,7 @@ if ( ! defined( 'GFEXCEL_PLUGIN_FILE' ) ) {
 }
 
 if ( ! defined( 'GFEXCEL_PLUGIN_VERSION' ) ) {
-	define( 'GFEXCEL_PLUGIN_VERSION', '2.0.5' );
+	define( 'GFEXCEL_PLUGIN_VERSION', '2.0.6' );
 }
 
 if ( ! defined( 'GFEXCEL_MIN_PHP_VERSION' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://www.gravitykit.com/extensions/gravityexport/?utm_source=plu
 Tags: Gravity Forms, GravityForms, Excel, Export, Download, Entries, CSV
 Requires at least: 4.0
 Requires PHP: 7.2
-Tested up to: 6.2
-Stable tag: 2.0.5
+Tested up to: 6.3
+Stable tag: 2.0.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -256,7 +256,7 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= Unreleased =
+= 2.0.6 on July 29, 2023 =
 
 * Bugfix: Checkbox lists without values in the entry could cause problems on transposed exports.
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Bugfix: Checkbox lists without values in the entry could cause problems on transposed exports.
+
 = 2.0.5 on July 13, 2023 =
 
 * Bugfix: Single option survey fields were no longer exported.

--- a/src/Field/CheckboxField.php
+++ b/src/Field/CheckboxField.php
@@ -6,55 +6,60 @@ namespace GFExcel\Field;
  * Field transformer for `checkbox` fields.
  * @since 1.8.8
  */
-class CheckboxField extends BaseField implements RowsInterface
-{
-    /**
-     * @inheritdoc
-     *
-     * Overwritten for phpdoc
-     *
-     * @var \GF_Field_Checkbox
-     */
-    protected $field;
+class CheckboxField extends BaseField implements RowsInterface {
+	/**
+	 * @inheritdoc
+	 *
+	 * Overwritten for phpdoc
+	 *
+	 * @var \GF_Field_Checkbox
+	 */
+	protected $field;
 
-    /**
-     * @inheritdoc
-     * @since 1.8.8
-     */
-    public function __construct(\GF_Field $field)
-    {
-        parent::__construct($field);
+	/**
+	 * @inheritdoc
+	 * @since 1.8.8
+	 */
+	public function __construct( \GF_Field $field ) {
+		parent::__construct( $field );
 
-        // Normal glue
-        add_filter('gfexcel_combiner_glue_checkbox', static function () {
-            return ', ';
-        });
-    }
+		// Normal glue
+		add_filter( 'gfexcel_combiner_glue_checkbox', static function () {
+			return ', ';
+		} );
+	}
 
-    /**
-     * @inheritdoc
-     * @since 1.8.8
-     */
-    public function getRows(?array $entry = null): iterable
-    {
-	    $inputs = $this->field->get_entry_inputs();
+	/**
+	 * @inheritdoc
+	 * @since 1.8.8
+	 */
+	public function getRows( ?array $entry = null ): iterable {
+		$inputs = $this->field->get_entry_inputs();
 
-        if (!is_array($inputs)) {
-            $value = \GFCommon::selection_display(
-                rgar($entry, $this->field->id),
-                $this->field,
-                rgar($entry, 'currency')
-            );
-            yield $this->wrap([$value]);
-        } else {
-            foreach ($inputs as $input) {
-                $index = (string) $input['id'];
-                if (!rgempty($index, $entry)) {
-	                $value = $this->filter_value( $this->getFieldValue( $entry, $index ), $entry );
+		if ( ! is_array( $inputs ) ) {
+			$value = \GFCommon::selection_display(
+				rgar( $entry, $this->field->id ),
+				$this->field,
+				rgar( $entry, 'currency' )
+			);
+			yield $this->wrap( [ $value ] );
+		} else {
+			$has_value = false;
+			foreach ( $inputs as $input ) {
+				$index = (string) $input['id'];
 
-	                yield $this->wrap([$value]);
-                }
-            }
-        }
-    }
+				if ( ! rgempty( $index, $entry ) ) {
+					$value = $this->filter_value( $this->getFieldValue( $entry, $index ), $entry );
+
+					$has_value = true;
+					yield $this->wrap( [ $value ] );
+				}
+			}
+
+			// Yield empty value to keep columns correct.
+			if ( ! $has_value ) {
+				yield $this->wrap( [ '' ] );
+			}
+		}
+	}
 }


### PR DESCRIPTION
Requirements for this bug:

- No multiple rows enabled
- Checkbox field without values in the entry
- Transposing the export

If a checkbox list had no selected values in the entry it would not yield any result, making the resulting entry row incomplete compared to the fields list. This is no problem for a normal export, but when transposing the array mismatch creates a broken array. 

example:

```php
$output = [
	//fields
	[
		0 => 'Some field',
		1 => 'checkbox list field',
		2 => 'third field',
	],
	// results
	[
		0 => 'Some value',
		2 => 'third value',
	]
];

// Broken:
$transposed = [
	[ 'Some field', 'some value' ],
	[ 'checkbox list field', 'third value' ],
	[ 'third field' ]
];
```