### PR TITLE
add ability to select more export fields from nested form

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -265,6 +265,7 @@ __Developer Updates:__
 
 * Added: `gk/gravityexport/settings/use-admin-labels` hook.
 * Added: `gk/gravityexport/field/use-admin-labels` hook.
+* Added: `gk/gravityexport/field/nested-form/export-field` hook to dynamically add other nested form fields to the export.
 
 __Developers__: This might be a breaking change to some plugins, if they directly reference any of the dependencies.
 

--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,7 @@ You can hide a row by adding a hook. Checkout this example:
 
 = develop =
 
+* Bugfix: Data from the old nested form could be exported if the nested form was changed.
 * Enhancement: Added global `Use admin label` setting.
 * Enhancement: Moved dependencies to a custom namespace to avoid collision with other plugins.
 

--- a/src/Field/CheckboxField.php
+++ b/src/Field/CheckboxField.php
@@ -44,21 +44,14 @@ class CheckboxField extends BaseField implements RowsInterface {
 			);
 			yield $this->wrap( [ $value ] );
 		} else {
-			$has_value = false;
 			foreach ( $inputs as $input ) {
 				$index = (string) $input['id'];
 
 				if ( ! rgempty( $index, $entry ) ) {
 					$value = $this->filter_value( $this->getFieldValue( $entry, $index ), $entry );
 
-					$has_value = true;
 					yield $this->wrap( [ $value ] );
 				}
-			}
-
-			// Yield empty value to keep columns correct.
-			if ( ! $has_value ) {
-				yield $this->wrap( [ '' ] );
 			}
 		}
 	}

--- a/src/Field/NestedFormField.php
+++ b/src/Field/NestedFormField.php
@@ -9,6 +9,8 @@ use GFExcel\Transformer\TransformerAwareInterface;
 /**
  * A field transformer for {@see \GP_Nested_Form_Field}.
  * @since 1.10
+ * @todo: Checkout weird values from the export. Are values being mixed?
+ * @todo: Output for nested forms is not working properly on non-separable setting.
  */
 class NestedFormField extends SeparableField implements RowsInterface, TransformerAwareInterface {
 	/**

--- a/src/Field/NestedFormField.php
+++ b/src/Field/NestedFormField.php
@@ -31,8 +31,8 @@ class NestedFormField extends SeparableField implements RowsInterface, Transform
 	 * @since 1.10
 	 */
 	public function getRows( ?array $entry = null ): iterable {
-		if ( ! class_exists( 'GP_Nested_Forms' ) ) {
-			yield [];
+		if ( ! class_exists( 'GP_Nested_Forms' ) || ! ( $this->field->gpnfForm ?? false ) ) {
+			yield [ '' ];
 		} else {
 			$value = $entry[ $this->field->id ] ?? '';
 			// Validate if the entries are from the connected form.
@@ -47,13 +47,18 @@ class NestedFormField extends SeparableField implements RowsInterface, Transform
 			] );
 
 			$nested_entries = \GP_Nested_Forms::get_instance()->get_entries( $ids );
-			$combiner = GFExcel::getCombiner( $this->field->formId );
 
-			foreach ( $nested_entries as $nested_entry ) {
-				$combiner->parseEntry( $this->getNestedFields(), $nested_entry );
+			if ( ! $nested_entries ) {
+				yield [ '' ];
+			} else {
+				$combiner = GFExcel::getCombiner( $this->field->formId );
+
+				foreach ( $nested_entries as $nested_entry ) {
+					$combiner->parseEntry( $this->getNestedFields(), $nested_entry );
+				}
+
+				yield from $combiner->getRows();
 			}
-
-			yield from $combiner->getRows();
 		}
 	}
 

--- a/src/Transformer/Combiner.php
+++ b/src/Transformer/Combiner.php
@@ -11,90 +11,98 @@ use GFExcel\Values\StringValue;
  * Combines multiple fields into one row for an entry.
  * @since 1.8.0
  */
-class Combiner implements CombinerInterface
-{
-    /**
-     * Holds an array of arrays that contains the cells data for every row.
-     * @since 1.8.0
-     * @var mixed[][] The rows with the cell values.
-     */
-    protected $rows = [];
+class Combiner implements CombinerInterface {
+	/**
+	 * Holds an array of arrays that contains the cells data for every row.
+	 * @since 1.8.0
+	 * @var mixed[][] The rows with the cell values.
+	 */
+	protected $rows = [];
 
-    /**
-     * @inheritDoc
-     * @since 1.8.0
-     */
-    public function parseEntry(array $fields, array $entry): void
-    {
-        // always start at zero.
-        $column_index = 0;
+	/**
+	 * @inheritDoc
+	 * @since 1.8.0
+	 */
+	public function parseEntry( array $fields, array $entry ): void {
+		// always start at zero.
+		$column_index = 0;
 
-        // Keep columns in internal array, so we only merge once.
-        $combined_row = [];
+		// Keep columns in internal array, so we only merge once.
+		$combined_row = [];
 
-        foreach ($fields as $field) {
-            $rows = $this->getFieldRows($field, $entry);
-            foreach ($rows as $cells) {
-                $i = 0;
-                foreach ($cells as $cell) {
-                    $combined_row[$column_index + $i][] = $cell;
-                    ++$i;
-                }
-            }
-            $column_index += count($field->getColumns());
-        }
+		foreach ( $fields as $field ) {
+			$rows     = $this->getFieldRows( $field, $entry );
+			$has_rows = false;
+			foreach ( $rows as $cells ) {
+				$has_rows = true;
+				$i        = 0;
+				foreach ( $cells as $cell ) {
+					$combined_row[ $column_index + $i ][] = $cell;
+					++ $i;
+				}
+			}
 
-        foreach ($combined_row as $column => $values) {
-            // only one row, so we can keep the value types.
-            if (count($values) === 1) {
-                $combined_row[$column] = reset($values);
-                continue;
-            }
+			// Make sure the row is filled with empty values.
+			if ( ! $has_rows ) {
+				foreach ( $field->getColumns() as $i => $_ ) {
+					$combined_row[ $column_index + $i ][] = null;
+				}
+			}
 
-            // Multiple rows, so we need to combine, and we MUST have a StringValue object.
-            $combined = array_reduce($values, static function (string $output, BaseValue $value): string {
-                if ($output !== '') {
-                    $output .= gf_apply_filters([
-                        'gfexcel_combiner_glue',
-                        $value->getFieldType(),
-                        $value->getFieldId(),
-                    ], "\n---\n", $value);
-                }
+			$column_index += count( $field->getColumns() );
+		}
 
-                $output .= $value->getValue();
+		foreach ( $combined_row as $column => $values ) {
+			// only one row, so we can keep the value types.
+			if ( count( $values ) === 1 ) {
+				$combined_row[ $column ] = reset( $values );
+				continue;
+			}
 
-                return $output;
-            }, '');
+			// Multiple rows, so we need to combine, and we MUST have a StringValue object.
+			$combined = array_reduce( $values, static function ( string $output, BaseValue $value ): string {
+				if ( $output !== '' ) {
+					$output .= gf_apply_filters( [
+						'gfexcel_combiner_glue',
+						$value->getFieldType(),
+						$value->getFieldId(),
+					], "\n---\n", $value );
+				}
 
-            $combined_row[$column] = new StringValue($combined, reset($values)->getField());
-        }
+				$output .= $value->getValue();
 
-        $this->rows[] = $combined_row;
-    }
+				return $output;
+			}, '' );
 
-    /**
-     * @inheritdoc
-     * @since 1.8.0
-     */
-    public function getRows(?array $entry = null): iterable
-    {
-        yield from $this->rows;
-    }
+			$combined_row[ $column ] = new StringValue( $combined, reset( $values )->getField() );
+		}
 
-    /**
-     * Retrieves the rows for a field.
-     * @since 1.8.0
-     * @param FieldInterface $field The field transformer.
-     * @param array $entry The entry object.
-     * @return iterable|\Generator|BaseValue[][] Rows containing cells.
-     */
-    protected function getFieldRows(FieldInterface $field, array $entry): iterable
-    {
-        // make sure custom legacy fields are processed as well.
-        if (!$field instanceof RowsInterface) {
-            yield $field->getCells($entry);
-        } else {
-            yield from $field->getRows($entry);
-        }
-    }
+		$this->rows[] = $combined_row;
+	}
+
+	/**
+	 * @inheritdoc
+	 * @since 1.8.0
+	 */
+	public function getRows( ?array $entry = null ): iterable {
+		yield from $this->rows;
+	}
+
+	/**
+	 * Retrieves the rows for a field.
+	 * @since 1.8.0
+	 *
+	 * @param FieldInterface $field The field transformer.
+	 * @param array $entry The entry object.
+	 *
+	 * @return iterable|\Generator|BaseValue[][] Rows containing cells.
+	 */
+	protected function getFieldRows( FieldInterface $field, array $entry ): iterable {
+		// make sure custom legacy fields are processed as well.
+		if ( ! $field instanceof RowsInterface ) {
+			yield $field->getCells( $entry );
+		} else {
+			yield from $field->getRows( $entry );
+		}
+	}
 }


### PR DESCRIPTION
This PR aims to Resolve #171 . 

- [x] Fix mixed values when values are not separated
- [x] Fix Output for nested forms not working properly on non-separable setting

(Other PR had weird commits).

The checkbox fix in #177 was to specific for checkboxes. Turns out it's for every field that has `RowInterface` that isn't yielding any rows. MultiRowCombiner already did this correctly; now the regular combiner also fixes the missing values.

Also enabled separation of fields for nested forms as default; because the combined values are unreadable. And now `repeater` and `nested form` both do this.  More consistent.