### PR TITLE
Adds global admin labels setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,9 +256,15 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= Unreleased =
+= develop =
 
-* Bugfix: Moved dependencies to a custom namespace to avoid collision with other plugins.
+* Enhancement: Added global `Use admin label` setting.
+* Enhancement: Moved dependencies to a custom namespace to avoid collision with other plugins.
+
+__Developer Updates:__
+
+* Added: `gk/gravityexport/settings/use-admin-labels` hook.
+* Added: `gk/gravityexport/field/use-admin-labels` hook.
 
 __Developers__: This might be a breaking change to some plugins, if they directly reference any of the dependencies.
 

--- a/src/Addon/GravityExportAddon.php
+++ b/src/Addon/GravityExportAddon.php
@@ -391,10 +391,11 @@ final class GravityExportAddon extends \GFFeedAddon implements AddonInterface, A
 			'title'       => esc_html__( 'Field settings', 'gk-gravityexport-lite' ),
 			'fields'      => [
 				[
-					'name'     => 'export-fields',
-					'type'     => 'sort_fields',
-					'choices'  => $this->getFields(),
-					'sections' => [
+					'name'             => 'export-fields',
+					'type'             => 'sort_fields',
+					'choices'          => $this->getFields(),
+					'use_admin_labels' => $this->useAdminLabels(),
+					'sections'         => [
 						'disabled' => [ esc_html__( 'Disabled Fields', 'gk-gravityexport-lite' ), 'enabled' ],
 						'enabled'  => [ esc_html__( 'Enabled Fields', 'gk-gravityexport-lite' ), 'disabled' ],
 					],
@@ -460,6 +461,20 @@ final class GravityExportAddon extends \GFFeedAddon implements AddonInterface, A
 			'title'       => esc_html__( 'Default Settings', 'gk-gravityexport-lite' ),
 			'description' => $this->plugin_settings_description(),
 			'fields'      => [
+				[
+					'name'    => 'labels',
+					'label'   => esc_html__( 'Labels', 'gk-gravityexport-lite' ),
+					'type'    => 'checkbox',
+					'choices' => [
+						[
+							'label' => esc_html__(
+								'Use admin labels',
+								'gk-gravityexport-lite'
+							),
+							'name'  => 'use_admin_label',
+						],
+					],
+				],
 				[
 					'name'    => 'field_separate',
 					'label'   => esc_html__( 'Multiple Columns', 'gk-gravityexport-lite' ),
@@ -813,27 +828,6 @@ final class GravityExportAddon extends \GFFeedAddon implements AddonInterface, A
 	}
 
 	/**
-	 * Retrieves the formatted label for a field.
-	 * @since 2.0.0
-	 *
-	 * @param \GF_Field $field The field.
-	 *
-	 * @return string The formatted label.
-	 */
-	private function get_field_label( \GF_Field $field ): string {
-		return gf_apply_filters(
-			[
-				'gfexcel_field_label',
-				$field->get_input_type(),
-				$field->formId,
-				$field->id,
-			],
-			$field->get_field_label( true, '' ),
-			$field
-		);
-	}
-
-	/**
 	 * @inheritdoc
 	 *
 	 * Overwritten to add custom after-render hook.
@@ -1095,6 +1089,18 @@ final class GravityExportAddon extends \GFFeedAddon implements AddonInterface, A
 			esc_attr( 'gk-gravityexport-meta-all' ),
 			esc_attr__( 'Deselect All', 'gk-gravityexport-lite' ),
 			esc_attr__( 'Select All', 'gk-gravityexport-lite' )
+		);
+	}
+
+	/**
+	 * Whether to use the admin labels as labels for the export.
+	 * @since $ver$
+	 * @return bool
+	 */
+	public function useAdminLabels(): bool {
+		return apply_filters(
+			'gk/gravityexport/settings/use-admin-labels',
+			(bool) $this->get_plugin_setting( 'use_admin_label' )
 		);
 	}
 }

--- a/src/Field/AbstractField.php
+++ b/src/Field/AbstractField.php
@@ -2,6 +2,7 @@
 
 namespace GFExcel\Field;
 
+use GFExcel\Addon\GravityExportAddon;
 use GFExcel\Values\BaseValue;
 
 /**
@@ -23,6 +24,9 @@ abstract class AbstractField implements FieldInterface {
 	 */
 	public function __construct( \GF_Field $field ) {
 		$this->field = $field;
+
+		// Make sure the field can export the admin label.
+		$field->set_context_property( 'use_admin_label', $this->useAdminLabels() );
 	}
 
 	/**
@@ -36,7 +40,7 @@ abstract class AbstractField implements FieldInterface {
 			$this->field->get_input_type(),
 			$this->field->formId,
 			$this->field->id
-		], $this->field->get_field_label( true, '' ), $this->field );
+		], $this->field->get_field_label( ! $this->useAdminLabels(), '' ), $this->field );
 
 		return $this->wrap( [ $label ], true );
 	}
@@ -139,5 +143,21 @@ abstract class AbstractField implements FieldInterface {
 
 		// add gform export filters to get the same results as a normal export
 		return apply_filters( 'gform_export_field_value', $value, $this->field->formId, $input_id, $entry );
+	}
+
+	/**
+	 * Whether the use of the admin label is allowed.
+	 * @since $ver$
+	 * @return bool
+	 */
+	protected function useAdminLabels(): bool {
+		return gf_apply_filters( [
+			'gk/gravityexport/field/use-admin-label',
+			$this->field->formId,
+			$this->field->id,
+		],
+			GravityExportAddon::get_instance()->useAdminLabels(),
+			$this->field,
+		);
 	}
 }

--- a/src/Field/AbstractField.php
+++ b/src/Field/AbstractField.php
@@ -26,7 +26,9 @@ abstract class AbstractField implements FieldInterface {
 		$this->field = $field;
 
 		// Make sure the field can export the admin label.
-		$field->set_context_property( 'use_admin_label', $this->useAdminLabels() );
+		if ( $this->useAdminLabels() ) {
+			$field->set_context_property( 'use_admin_label', true );
+		}
 	}
 
 	/**
@@ -157,7 +159,7 @@ abstract class AbstractField implements FieldInterface {
 			$this->field->id,
 		],
 			GravityExportAddon::get_instance()->useAdminLabels(),
-			$this->field,
+			$this->field
 		);
 	}
 }

--- a/src/GravityForms/Field/SortFields.php
+++ b/src/GravityForms/Field/SortFields.php
@@ -41,6 +41,13 @@ class SortFields extends Base {
 	public $sections = [];
 
 	/**
+	 * Whether the labels can be admin labels.
+	 * @since $ver$
+	 * @var bool
+	 */
+	public $use_admin_labels = false;
+
+	/**
 	 * @inheritDoc
 	 * @since 2.0.0
 	 */
@@ -108,7 +115,7 @@ class SortFields extends Base {
                 </div>
             </li>',
 			$choice->id,
-			$choice->label
+			$choice->get_field_label( !$this->use_admin_labels, '' )
 		);
 	}
 

--- a/tests/Transformer/TransformerTest.php
+++ b/tests/Transformer/TransformerTest.php
@@ -2,7 +2,6 @@
 
 namespace GFExcel\Tests\Transformer;
 
-use GFExcel\Field\BaseField;
 use GFExcel\Field\FieldInterface;
 use GFExcel\Field\SeparableField;
 use GFExcel\Tests\TestCase;
@@ -58,28 +57,12 @@ final class TransformerTest extends TestCase {
 	public function testTransformWithSeparableField(): void {
 		$transformer = new TestTransformer();
 
-
 		$this->field->method( 'get_input_type' )->willReturn( 'separable' );
 		$this->field->method( 'get_entry_inputs' )->willReturn( [ '1', '2' ] );
 
 		$field = $transformer->transform( $this->field );
 
 		self::assertInstanceOf( SeparableField::class, $field );
-	}
-
-	/**
-	 * Test case for {@see Transformer::getField()} with a base field.
-	 * @return void
-	 */
-	public function testTransformWithBaseField(): void {
-		$transformer = new TestTransformer();
-
-		$this->field->method( 'get_input_type' )->willReturn( 'separable' );
-		$this->field->method( 'get_entry_inputs' )->willReturn( [ '1', '2' ] );
-
-		$field = $transformer->transform( $this->field );
-
-		self::assertInstanceOf( BaseField::class, $field );
 	}
 }
 
@@ -104,12 +87,19 @@ final class TestField implements FieldInterface, TransformerAwareInterface {
 	}
 }
 
+final class TestSeparableField extends SeparableField {
+	protected function useAdminLabels(): bool {
+		return false;
+	}
+}
+
 /**
  * Test transformer that overwrites the default fields list.
  * @since 1.1.11
  */
 final class TestTransformer extends Transformer {
 	protected $fields = [
-		'test' => TestField::class,
+		'test'      => TestField::class,
+		'separable' => TestSeparableField::class,
 	];
 }


### PR DESCRIPTION
This PR Resolves #176 by adding a global `Use admin labels` setting for the plugin. 

There are also 2 hooks: 

- `gk/gravityexport/settings/use-admin-labels` to programmatically enable the labels
- `gk/gravityexport/field/use-admin-labels` to enable / disable the label for specific forms and fields