### PR TITLE
fix invalid type for callback

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Bugfix: Nested forms with missing entries could create a critical issue.
+
 = 2.1.0 on September 25, 2023 =
 
 * Bugfix: Data from the old nested form could be exported if the nested form was changed.

--- a/src/Shorttag/DownloadUrl.php
+++ b/src/Shorttag/DownloadUrl.php
@@ -9,6 +9,7 @@ use GFExcel\GFExcel;
  * Example usage: [gfexcel_download_url id=1 type=csv]
  * Id is required, type is optional.
  * @since 1.6.1
+ * @final Will become actually final in the next major.
  */
 class DownloadUrl
 {

--- a/src/Transformer/Combiner.php
+++ b/src/Transformer/Combiner.php
@@ -2,6 +2,7 @@
 
 namespace GFExcel\Transformer;
 
+use GF_Field;
 use GFExcel\Field\FieldInterface;
 use GFExcel\Field\RowsInterface;
 use GFExcel\Values\BaseValue;
@@ -59,8 +60,11 @@ class Combiner implements CombinerInterface {
 				continue;
 			}
 
-			// Multiple rows, so we need to combine, and we MUST have a StringValue object.
-			$combined = array_reduce( $values, static function ( string $output, BaseValue $value ): string {
+			$combined = array_reduce( $values, static function ( string $output, ?BaseValue $value ): string {
+				if ( ! $value ) {
+					return $output;
+				}
+
 				if ( $output !== '' ) {
 					$output .= gf_apply_filters( [
 						'gfexcel_combiner_glue',
@@ -74,7 +78,9 @@ class Combiner implements CombinerInterface {
 				return $output;
 			}, '' );
 
-			$combined_row[ $column ] = new StringValue( $combined, reset( $values )->getField() );
+			$gf_field = array_filter( $values ) ? reset( $values )->getField() : new GF_Field();
+
+			$combined_row[ $column ] = new StringValue( $combined, $gf_field );
 		}
 
 		$this->rows[] = $combined_row;


### PR DESCRIPTION
In a previous attempt to fill out a forms columns, I've added a `null` value to add an empty cell. The callback expected a `BaseValue`. 

This PR fixes that, and makes sure it is a valid empty string object.