### PR TITLE
Update Strauss

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,6 +100,7 @@
             "classmap_output": false,
             "delete_vendor_packages": true,
             "delete_vendor_files": true,
+            "include_modified_date": false,
             "exclude_from_prefix": {
                 "namespaces": [
                     "GFExcel"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d862b87a2548dbf43760d5b03b874ed",
+    "content-hash": "7564e97630d48d1ac2e735bcb6193f3b",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",


### PR DESCRIPTION
The old version of Strauss is causing some exceptions to occur on PHP 8, with its more strict typing. 

This PR replaces Strauss with a newer version; and removes the date from the Strauss header. This will prevent a deploy from taking almost 30 minutes in the future.

💾 [Build file](https://www.dropbox.com/scl/fi/7kuhic4zh3mhvmpfgn2cc/gf-entries-in-excel-2.3.3-7191355.zip?rlkey=3jer2z0uu5mx04231ne0mj1hm&dl=1) (7191355).