### PR TITLE
Empty value filter for checkbox field with no selected option

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,11 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Fixed: Type errors on fields no longer cause exports to fail. Values become empty, and errors are logged.
+* Enhancement: Added a `gfexcel_field_checkbox_empty` filter to control checkbox output, when no option was selected.
+
 = 2.3.5 on November 25, 2024 =
 
 * Fixed: PHP notice in WordPress 6.7 caused by initializing product translations too early.

--- a/src/Field/AbstractField.php
+++ b/src/Field/AbstractField.php
@@ -4,6 +4,7 @@ namespace GFExcel\Field;
 
 use GFExcel\Addon\GravityExportAddon;
 use GFExcel\Values\BaseValue;
+use Throwable;
 
 /**
  * @since 1.0.0
@@ -137,7 +138,13 @@ abstract class AbstractField implements FieldInterface {
 			return date_i18n( 'Y-m-d H:i:s', $lead_local_time, true );
 		}
 
-		$value = $this->field->get_value_export( $entry, $input_id, $use_text = false, $is_csv = false );
+		// Prevent Type Errors from fields.
+		try {
+			$value = $this->field->get_value_export( $entry, $input_id, $use_text = false, $is_csv = false );
+		} catch ( Throwable $error ) {
+			GravityExportAddon::get_instance()->log_error( $error->getMessage() );
+			$value = null;
+		}
 
 		if ( is_string( $value ) ) {
 			$value = html_entity_decode( $value );

--- a/src/Field/CheckboxField.php
+++ b/src/Field/CheckboxField.php
@@ -44,13 +44,31 @@ class CheckboxField extends BaseField implements RowsInterface {
 			);
 			yield $this->wrap( [ $value ] );
 		} else {
+			$has_values = false;
 			foreach ( $inputs as $input ) {
 				$index = (string) $input['id'];
 
 				if ( ! rgempty( $index, $entry ) ) {
-					$value = $this->filter_value( $this->getFieldValue( $entry, $index ), $entry );
-
+					$has_values = true;
+					$value      = $this->filter_value( $this->getFieldValue( $entry, $index ), $entry );
 					yield $this->wrap( [ $value ] );
+				}
+			}
+
+			if ( ! $has_values ) {
+				$empty_value = gf_apply_filters(
+					[
+						'gfexcel_field_checkbox_empty',
+						$this->field->formId,
+						$this->field->id,
+					],
+					'',
+					$entry,
+					$this->field
+				);
+
+				if ( '' !== $empty_value ) {
+					yield $this->wrap( [ $empty_value ] );
 				}
 			}
 		}


### PR DESCRIPTION
In response to https://wordpress.org/support/topic/how-to-handle-empty-dropdown-fields-in-the-export-using-hooks/#post-18198528 i've added a `gfexcel_field_checkbox_empty` filter. This receives the default value of `''`, the entry and the field object. It can also be hooked into as `gfexcel_field_checkbox_empty_<form_id>` or `gfexcel_field_checkbox_empty_<formid>_<fieldid>`.

💾 [Build file](https://www.dropbox.com/scl/fi/0tkznlkj0c0vnn3akrhd7/gf-entries-in-excel-2.3.5-135d542.zip?rlkey=wxf7m7aoa8bgtyn8nb52yhw97&dl=1) (135d542).