### PR TITLE
Fixed warning of incorrect migrations path on builds (#209)

### DIFF
--- a/gfexcel.php
+++ b/gfexcel.php
@@ -63,11 +63,18 @@ add_action( 'gform_loaded', static function (): void {
 	}
 
 	$autoload_file = __DIR__ . '/build/vendor/autoload.php';
-	$is_build      = true;
+	$src_folder    = __DIR__ . '/build/vendor_prefixed/gravitykit/gravityexport-lite-src';
+
+	$is_build = true;
 	if ( ! file_exists( $autoload_file ) ) {
 		$autoload_file = __DIR__ . '/vendor/autoload.php';
 		$is_build      = false;
 	}
+
+	if ( ! $is_build || ! is_readable( $src_folder ) ) {
+		$src_folder = __DIR__ . '/src';
+	}
+	define( 'GFEXCEL_SRC_FOLDER', $src_folder );
 
 	require_once $autoload_file;
 

--- a/gfexcel.php
+++ b/gfexcel.php
@@ -35,6 +35,12 @@ if ( ! defined( 'GFEXCEL_MIN_PHP_VERSION' ) ) {
 	define( 'GFEXCEL_MIN_PHP_VERSION', '7.2' );
 }
 
+$src_folder    = __DIR__ . '/build/vendor_prefixed/gravitykit/gravityexport-lite-src';
+if ( ! is_readable( $src_folder ) ) {
+	$src_folder = __DIR__ . '/src';
+}
+define( 'GFEXCEL_SRC_FOLDER', $src_folder );
+
 if ( version_compare( phpversion(), GFEXCEL_MIN_PHP_VERSION, '<' ) ) {
 	$show_minimum_php_version_message = function () {
 		$message = wpautop( sprintf( esc_html__( 'GravityExport Lite requires PHP %s or newer.', 'gk-gravityexport-lite' ), GFEXCEL_MIN_PHP_VERSION ) );
@@ -63,18 +69,12 @@ add_action( 'gform_loaded', static function (): void {
 	}
 
 	$autoload_file = __DIR__ . '/build/vendor/autoload.php';
-	$src_folder    = __DIR__ . '/build/vendor_prefixed/gravitykit/gravityexport-lite-src';
 
 	$is_build = true;
 	if ( ! file_exists( $autoload_file ) ) {
 		$autoload_file = __DIR__ . '/vendor/autoload.php';
 		$is_build      = false;
 	}
-
-	if ( ! $is_build || ! is_readable( $src_folder ) ) {
-		$src_folder = __DIR__ . '/src';
-	}
-	define( 'GFEXCEL_SRC_FOLDER', $src_folder );
 
 	require_once $autoload_file;
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Fixed: A warning would appear when upgrading GravityExport Lite.
+
 = 2.3.6 on December 18, 2024 =
 
 * Fixed: Type errors on fields no longer cause exports to fail. Values become empty, and errors are logged.

--- a/src/Migration/Manager/MigrationManager.php
+++ b/src/Migration/Manager/MigrationManager.php
@@ -72,6 +72,8 @@ class MigrationManager {
 			$this->migrate();
 		} catch ( MigrationException $e ) {
 			GravityExportAddon::get_instance()->log_error( sprintf( 'Migration error: %s', $e->getMessage() ) );
+			// Clear running status.
+			$this->repository->setRunning( false );
 		}
 	}
 

--- a/src/Migration/Repository/FileSystemMigrationRepository.php
+++ b/src/Migration/Repository/FileSystemMigrationRepository.php
@@ -51,6 +51,10 @@ final class FileSystemMigrationRepository implements MigrationRepositoryInterfac
 	 * @since 2.0.0
 	 */
 	public function getMigrations(): array {
+		if ( ! is_readable( $this->migration_path ) ) {
+			return [];
+		}
+
 		// Change directory for glob. We do this here, so we can better test `getMigrations()`.
 		chdir( $this->migration_path );
 

--- a/src/ServiceProvider/AddOnProvider.php
+++ b/src/ServiceProvider/AddOnProvider.php
@@ -59,7 +59,7 @@ class AddOnProvider extends AbstractServiceProvider {
 		$container = $this->getContainer();
 
 		$container->add( MigrationRepositoryInterface::class, FileSystemMigrationRepository::class )
-		          ->addArgument( dirname( GFEXCEL_PLUGIN_FILE ) . '/src/Migration/Migration/' );
+		          ->addArgument( GFEXCEL_SRC_FOLDER . '/Migration/Migration/' );
 		$container->add( NotificationRepositoryInterface::class, NotificationRepository::class );
 		$container->add( NotificationManager::class )->addArgument( NotificationRepositoryInterface::class );
 


### PR DESCRIPTION
When we moved the plugin over to Strauss the `Migrations` were also moved to `vendor_prefixed`, while the container was still configured to the old `<plugin>/src/..` folder. Since the builds no longer have this folder, it caused a warning. 

This PR resolves that issue (#209) by adding a `is_readable` check on the folder, and a change of folder-root (`GFEXCEL_SRC_FOLDER`) when it concerns a *build*. 

It also fixed a tiny "bug" where, when a migration fails for an unrecoverable reason, the migration state is reset from `running`.  This will make it possible for a migration to try again sooner.

💾 [Build file](https://www.dropbox.com/scl/fi/16f81z7kc1io7jibyz8ib/gf-entries-in-excel-2.3.6-acaf95c.zip?rlkey=bxq62g1prucuxohkrc5mta2yg&dl=1) (acaf95c).