### PR TITLE
Fix WordPress translation notice

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Fixed: PHP notice in WordPress 6.8 caused by initializing product translations too early.
+
 = 2.3.8 on January 27, 2025 =
 
 * Enhancement: Nested forms can now also export entry meta values.

--- a/src/Action/DownloadUrlEnableAction.php
+++ b/src/Action/DownloadUrlEnableAction.php
@@ -23,7 +23,7 @@ class DownloadUrlEnableAction extends DownloadUrlResetAction {
 	public function __construct( HashGeneratorInterface $generator ) {
 		parent::__construct( $generator );
 
-		static::$success_message = esc_html__( 'The download URL has been enabled.', 'gk-gravityexport-lite' );
+		static::$success_message = 'The download URL has been enabled.';
 	}
 
 	/**

--- a/src/Action/DownloadUrlResetAction.php
+++ b/src/Action/DownloadUrlResetAction.php
@@ -38,7 +38,7 @@ class DownloadUrlResetAction extends AbstractAction {
 	public function __construct( HashGeneratorInterface $generator ) {
 		$this->generator = $generator;
 
-		static::$success_message = esc_html__( 'The download URL has been reset.', 'gk-gravityexport-lite' );
+		static::$success_message = 'The download URL has been reset.';
 	}
 
 	/**
@@ -73,6 +73,6 @@ class DownloadUrlResetAction extends AbstractAction {
 		$addon->set_previous_settings( $settings );
 
 		// Set notification of success.
-		$addon->add_message( static::$success_message );
+		$addon->add_message( esc_html__( static::$success_message, 'gk-gravityexport-lite' ) );
 	}
 }


### PR DESCRIPTION
Fixes the translation notices for WordPress 6.8. 

💾 [Build file](https://www.dropbox.com/scl/fi/4x0dv17tnexkqocddw2cn/gf-entries-in-excel-2.3.8-c22adee.zip?rlkey=kossc9k54jtyrkqcky000g5m8&dl=1) (c22adee).