### PR TITLE
Fix relative clipboard.js src on the Activate GravityExport screen

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,8 @@ includes:
   - phar://phpstan.phar/conf/bleedingEdge.neon
   # Include this extension
   - vendor/szepeviktor/phpstan-wordpress/extension.neon
+  # Type inference for Mockery mocks (Mockery::mock(X::class) is X&MockInterface)
+  - vendor/phpstan/phpstan-mockery/extension.neon
 parameters:
   level: 5
   bootstrapFiles:
@@ -26,6 +28,11 @@ parameters:
   paths:
     - src
     - tests
+
+  excludePaths:
+    # Runtime-only test doubles for classes that already exist in the scanned
+    # vendor dirs; analyzing them would shadow the real Gravity Forms classes.
+    - tests/stubs
 
   scanDirectories:
     - vendor/gravityforms/gravityforms # Gravity Forms has no `autoload` section, so we need to configure the path.

--- a/src/Addon/GravityExportAddon.php
+++ b/src/Addon/GravityExportAddon.php
@@ -295,8 +295,9 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 				'title'  => __( 'Activate GravityExport', 'gk-gravityexport-lite' ),
 				'fields' => [
 					[
-						'name' => 'hash',
-						'type' => 'download_url',
+						'name'       => 'hash',
+						'type'       => 'download_url',
+						'assets_dir' => $this->assets_dir,
 					],
 				],
 			];

--- a/src/GravityForms/Field/DownloadUrl.php
+++ b/src/GravityForms/Field/DownloadUrl.php
@@ -148,10 +148,15 @@ $script = <<<JS
 })(jQuery);
 JS;
 
+		// A field instantiated without `assets_dir` (e.g. the "Activate GravityExport"
+		// section) must not emit a relative src: WordPress concatenates it straight
+		// onto site_url(), producing a malformed `<host>js/clipboard.js` request.
+		$assets_dir = $this->assets_dir ?: plugin_dir_url( GFEXCEL_PLUGIN_FILE ) . 'public/';
+
 		return [
 			[
 				'handle'   => 'gk-gravityexport-clipboard-js',
-				'src'      => $this->assets_dir . 'js/clipboard.js',
+				'src'      => $assets_dir . 'js/clipboard.js',
 				'callback' => function () use ( $script ) {
 					wp_add_inline_script(
 						'gk-gravityexport-clipboard-js',

--- a/tests/GravityForms/Field/DownloadUrlTest.php
+++ b/tests/GravityForms/Field/DownloadUrlTest.php
@@ -1,75 +1,58 @@
 <?php
 
-namespace Gravity_Forms\Gravity_Forms\Settings\Fields {
-	if ( ! class_exists( __NAMESPACE__ . '\Text' ) ) {
-		/**
-		 * Minimal stand-in for Gravity Forms' settings Text field, which is not
-		 * available in the unit-test context. Mirrors the prop-copying constructor
-		 * the real base class uses.
-		 */
-		class Text {
-			public function __construct( $props = [], $settings = null ) {
-				foreach ( (array) $props as $prop => $value ) {
-					$this->{$prop} = $value;
-				}
-			}
-		}
-	}
-}
+namespace GFExcel\Tests\GravityForms\Field;
 
-namespace GFExcel\Tests\GravityForms\Field {
+use GFExcel\GravityForms\Field\DownloadUrl;
+use GFExcel\Tests\TestCase;
+use Gravity_Forms\Gravity_Forms\Settings\Settings;
 
-	use GFExcel\GravityForms\Field\DownloadUrl;
-	use GFExcel\Tests\TestCase;
-
+/**
+ * Unit tests for {@see DownloadUrl}.
+ * @since 2.6.1
+ */
+class DownloadUrlTest extends TestCase {
 	/**
-	 * Unit tests for {@see DownloadUrl}.
+	 * The clipboard script must resolve inside the plugin whether or not the field
+	 * was constructed with an `assets_dir` — a relative src would be concatenated
+	 * straight onto site_url() by WordPress, emitting a malformed
+	 * `<host>js/clipboard.js` request (no path separator).
+	 *
 	 * @since 2.6.1
 	 */
-	class DownloadUrlTest extends TestCase {
-		/**
-		 * The clipboard script must resolve inside the plugin whether or not the field
-		 * was constructed with an `assets_dir` — a relative src would be concatenated
-		 * straight onto site_url() by WordPress, emitting a malformed
-		 * `<host>js/clipboard.js` request (no path separator).
-		 *
-		 * @since 2.6.1
-		 */
-		public function testScriptsSrcIsAbsoluteWithoutAssetsDir(): void {
-			\WP_Mock::userFunction( 'plugin_dir_url', [
-				'return' => 'https://example.test/wp-content/plugins/gk-gravityexport-lite/',
-			] );
+	public function testScriptsSrcIsAbsoluteWithoutAssetsDir(): void {
+		\WP_Mock::userFunction( 'plugin_dir_url', [
+			'return' => 'https://example.test/wp-content/plugins/gk-gravityexport-lite/',
+		] );
 
-			$field = new DownloadUrl( [ 'name' => 'hash', 'type' => 'download_url' ], null );
+		$field = new DownloadUrl( [ 'name' => 'hash', 'type' => 'download_url' ], \Mockery::mock( Settings::class ) );
 
-			$scripts = $field->scripts();
+		$scripts = $field->scripts();
 
-			$this->assertSame(
-				'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/js/clipboard.js',
-				$scripts[0]['src']
-			);
-		}
+		$this->assertSame(
+			'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/js/clipboard.js',
+			$scripts[0]['src']
+		);
+	}
 
-		/**
-		 * An explicitly provided assets_dir keeps winning.
-		 * @since 2.6.1
-		 */
-		public function testScriptsSrcUsesProvidedAssetsDir(): void {
-			$field = new DownloadUrl(
-				[
-					'name'       => 'hash',
-					'type'       => 'download_url',
-					'assets_dir' => 'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/',
-				],
-				null
-			);
+	/**
+	 * An explicitly provided assets_dir keeps winning.
+	 * @since 2.6.1
+	 */
+	public function testScriptsSrcUsesProvidedAssetsDir(): void {
+		$field = new DownloadUrl(
+			[
+				'name'       => 'hash',
+				'type'       => 'download_url',
+				'assets_dir' => 'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/',
+			],
+			\Mockery::mock( Settings::class )
+		);
 
-			$scripts = $field->scripts();
+		$scripts = $field->scripts();
 
-			$this->assertSame(
-				'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/js/clipboard.js',
-				$scripts[0]['src']
-			);
-		}
+		$this->assertSame(
+			'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/js/clipboard.js',
+			$scripts[0]['src']
+		);
 	}
 }

--- a/tests/GravityForms/Field/DownloadUrlTest.php
+++ b/tests/GravityForms/Field/DownloadUrlTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Gravity_Forms\Gravity_Forms\Settings\Fields {
+	if ( ! class_exists( __NAMESPACE__ . '\Text' ) ) {
+		/**
+		 * Minimal stand-in for Gravity Forms' settings Text field, which is not
+		 * available in the unit-test context. Mirrors the prop-copying constructor
+		 * the real base class uses.
+		 */
+		class Text {
+			public function __construct( $props = [], $settings = null ) {
+				foreach ( (array) $props as $prop => $value ) {
+					$this->{$prop} = $value;
+				}
+			}
+		}
+	}
+}
+
+namespace GFExcel\Tests\GravityForms\Field {
+
+	use GFExcel\GravityForms\Field\DownloadUrl;
+	use GFExcel\Tests\TestCase;
+
+	/**
+	 * Unit tests for {@see DownloadUrl}.
+	 * @since 2.6.1
+	 */
+	class DownloadUrlTest extends TestCase {
+		/**
+		 * The clipboard script must resolve inside the plugin whether or not the field
+		 * was constructed with an `assets_dir` — a relative src would be concatenated
+		 * straight onto site_url() by WordPress, emitting a malformed
+		 * `<host>js/clipboard.js` request (no path separator).
+		 *
+		 * @since 2.6.1
+		 */
+		public function testScriptsSrcIsAbsoluteWithoutAssetsDir(): void {
+			\WP_Mock::userFunction( 'plugin_dir_url', [
+				'return' => 'https://example.test/wp-content/plugins/gk-gravityexport-lite/',
+			] );
+
+			$field = new DownloadUrl( [ 'name' => 'hash', 'type' => 'download_url' ], null );
+
+			$scripts = $field->scripts();
+
+			$this->assertSame(
+				'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/js/clipboard.js',
+				$scripts[0]['src']
+			);
+		}
+
+		/**
+		 * An explicitly provided assets_dir keeps winning.
+		 * @since 2.6.1
+		 */
+		public function testScriptsSrcUsesProvidedAssetsDir(): void {
+			$field = new DownloadUrl(
+				[
+					'name'       => 'hash',
+					'type'       => 'download_url',
+					'assets_dir' => 'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/',
+				],
+				null
+			);
+
+			$scripts = $field->scripts();
+
+			$this->assertSame(
+				'https://example.test/wp-content/plugins/gk-gravityexport-lite/public/js/clipboard.js',
+				$scripts[0]['src']
+			);
+		}
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/stubs/gravity-forms-settings-text.php';
 if (!defined('GFEXCEL_PLUGIN_FILE')) {
     define('GFEXCEL_PLUGIN_FILE', dirname(__FILE__, 2) . '/gfexcel.php');
 }

--- a/tests/stubs/gravity-forms-settings-text.php
+++ b/tests/stubs/gravity-forms-settings-text.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Minimal stand-in for Gravity Forms' settings Text field, which is not
+ * available in the unit-test context. Mirrors the prop-copying constructor
+ * the real base class uses.
+ *
+ * Loaded from tests/bootstrap.php only. Excluded from PHPStan analysis
+ * (see phpstan.neon.dist) so static analysis resolves the real class from
+ * vendor/gravityforms instead of this stub.
+ *
+ * @since 2.6.1
+ */
+
+namespace Gravity_Forms\Gravity_Forms\Settings\Fields;
+
+if ( ! class_exists( __NAMESPACE__ . '\Text' ) ) {
+	class Text {
+		/** @var mixed The settings renderer instance, kept for fields whose save() consults it. */
+		public $settings;
+
+		public function __construct( $props = [], $settings = null ) {
+			$this->settings = $settings;
+
+			foreach ( (array) $props as $prop => $value ) {
+				$this->{$prop} = $value;
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

The "Activate GravityExport" settings section (shown until a form's download URL is enabled) builds its `download_url` field **without** `assets_dir`, so `DownloadUrl::scripts()` returns `'src' => '' . 'js/clipboard.js'`. WordPress prepends `site_url()` to a relative src with no separator, so every visit to that screen requests:

```
https://<site>js/clipboard.js?ver=<wp-version>
```

— a malformed URL (observed as `net::ERR_NAME_NOT_RESOLVED` during GravityKit demo QA, Linear MAR-102). The section 30 lines below passes `assets_dir` correctly; this one was missed.

## Fix

1. Pass `'assets_dir' => $this->assets_dir` where the Activate section is built (`GravityExportAddon.php`).
2. Belt-and-braces fallback in `DownloadUrl::scripts()`: `$this->assets_dir ?: plugin_dir_url( GFEXCEL_PLUGIN_FILE ) . 'public/'`, so no future caller can reintroduce the relative src.

## Tests

New `tests/GravityForms/Field/DownloadUrlTest.php`:
- field constructed without `assets_dir` → absolute src via the fallback (failed before the fix with the literal `js/clipboard.js`)
- field constructed with `assets_dir` → uses it unchanged

Full suite: 125 tests, 256 assertions, green.

## Related (not fixed here, worth a follow-up)

`CopyShortcode::scripts()` registers the **same** `gk-gravityexport-clipboard-js` handle with no `src` at all — whichever field enqueues first wins the handle, so a filter that reorders settings sections silently kills `addClipboard()` for both buttons. Distinct handles (or a shared registered dependency) would remove that ordering hazard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed clipboard script URLs for download fields when no custom assets directory is configured.
  - Ensured configured asset directories are used correctly.
  - Activation download fields now generate valid asset URLs.

- **Tests**
  - Added coverage for download URL handling with default and custom asset directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/5u6575yg5k5069po9vtia/gf-entries-in-excel-2.7.1-7ffdf34.zip?rlkey=2f4bqdy1s5p7zjaidgalyk0hg&dl=1) (7ffdf34).