### PR TITLE
Send Content-Type: application/pdf for PDF downloads

### DIFF
--- a/src/Renderer/AbstractPHPExcelRenderer.php
+++ b/src/Renderer/AbstractPHPExcelRenderer.php
@@ -133,6 +133,8 @@ abstract class AbstractPHPExcelRenderer extends AbstractRenderer implements Rend
                 header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
             } elseif ($extension === 'csv') {
                 header('Content-Type: text/csv');
+            } elseif ($extension === 'pdf') {
+                header('Content-Type: application/pdf');
             }
 
             header('Content-Disposition: attachment;filename="' . $this->getFileName() . '"');


### PR DESCRIPTION
The download endpoint sets an explicit `Content-Type` for `xlsx` and `csv` but not `pdf`, so PDF exports are served as PHP's default `text/html; charset=UTF-8` under a `.pdf` filename. The bytes are a valid PDF (`%PDF-1.4 … %%EOF`) so sniffing browsers cope, but anything trusting the header — proxies, inline previewers, strict HTTP clients — mishandles the file.

One-line addition to the extension switch in `AbstractPHPExcelRenderer::renderOutput()`.

Found during demo QA (Linear MAR-104: "PDF download returns Content-Type: text/html under a .pdf filename").

💾 [Build file](https://www.dropbox.com/scl/fi/5wjs7uux292gd6e69puyr/gf-entries-in-excel-2.7.1-de4133f.zip?rlkey=0p3c4334e4tw1yn7xg15qglox&dl=1) (de4133f).